### PR TITLE
Update CodeFleet cask to 0.7.0

### DIFF
--- a/Casks/codefleet.rb
+++ b/Casks/codefleet.rb
@@ -1,8 +1,8 @@
 cask "codefleet" do
-  version "0.6.1"
-  sha256 "458206b22738d5bb75e1a38514bb3de0597f3af213eadea4c9870cbb5936571f"
+  version "0.7.0"
+  sha256 "fd6efd644eef6ffede24cb9c887d97c6d2ae793365bdd5d1ba641fc2d96f348e"
 
-  url "https://codefleet.app/api/download/brew/macos/0.6.1"
+  url "https://codefleet.app/api/download/brew/macos/0.7.0"
   name "CodeFleet"
   desc "AI-first development workspace for seamless collaboration with multiple AI coding assistants"
   homepage "https://codefleet.app"


### PR DESCRIPTION
Updates the Homebrew cask for CodeFleet 0.7.0.

Release summary:
- **Preserve PR selection** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Create from GitHub PRs** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Expose ungroup drop target** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Hide empty ungrouped section** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Add project groups** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.

Verification:
- Release plan generated by `npm run release:plan`.
- Artifact upload and public download verification are performed by `npm run release:publish`.