### PR TITLE
Update CodeFleet cask to 0.8.0

### DIFF
--- a/Casks/codefleet.rb
+++ b/Casks/codefleet.rb
@@ -1,8 +1,8 @@
 cask "codefleet" do
-  version "0.7.0"
-  sha256 "fd6efd644eef6ffede24cb9c887d97c6d2ae793365bdd5d1ba641fc2d96f348e"
+  version "0.8.0"
+  sha256 "2ef7a506206106fef700ec3dad117f349903c52f7696d1e1582bf35c7a1cbc96"
 
-  url "https://codefleet.app/api/download/brew/macos/0.7.0"
+  url "https://codefleet.app/api/download/brew/macos/0.8.0"
   name "CodeFleet"
   desc "AI-first development workspace for seamless collaboration with multiple AI coding assistants"
   homepage "https://codefleet.app"


### PR DESCRIPTION
Updates the Homebrew cask for CodeFleet 0.8.0.

Release summary:
- **Auto-send browser prompt** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Render prompt inside webview** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Float component prompt card** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Keep page visible while prompting** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Chip terminal context** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Prompt selected components** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Auto-connect new worktrees** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Add file row actions** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Yield ⌘K to focused terminals; align palette UI with quick-open** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.

Verification:
- Release plan generated by `npm run release:plan`.
- Artifact upload and public download verification are performed by `npm run release:publish`.