### PR TITLE
Update CodeFleet cask to 0.10.0

### DIFF
--- a/Casks/codefleet.rb
+++ b/Casks/codefleet.rb
@@ -1,8 +1,8 @@
 cask "codefleet" do
-  version "0.9.0"
-  sha256 "49a8582f63c8f452e560c4d483df84b9d4d08591e880998d52b2890c433b7237"
+  version "0.10.0"
+  sha256 "3ed5d8573a948b7e1e571219349986a45f2064ae3137a978c4dcf2272cb04915"
 
-  url "https://codefleet.app/api/download/brew/macos/0.9.0"
+  url "https://codefleet.app/api/download/brew/macos/0.10.0"
   name "CodeFleet"
   desc "AI-first development workspace for seamless collaboration with multiple AI coding assistants"
   homepage "https://codefleet.app"


### PR DESCRIPTION
Updates the Homebrew cask for CodeFleet 0.10.0.

Release summary:
- **Add cancelable github clone session** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Preserve history pagination on resume** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Observe history top sentinel** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Harden history pagination trigger** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Load older entries on scroll** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Page persisted transcript loads** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Suppress resume replay floods** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Avoid blocking history loads** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.
- **Clone projects from GitHub** — This release includes the change from the corresponding app update. Review and edit this draft before publishing.

Verification:
- Release plan generated by `npm run release:plan`.
- Artifact upload and public download verification are performed by `npm run release:publish`.